### PR TITLE
fix: patch basic-ftp CRLF injection (GHSA-6v7q-wjvx-w8wg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "garden-god-mother",
+  "name": "garden-godmother",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "puppeteer": "^24.40.0"
+  },
+  "overrides": {
+    "basic-ftp": ">=5.2.2"
   }
 }


### PR DESCRIPTION
## Summary
- Pins `basic-ftp` to >= 5.2.2 via npm overrides to fix GHSA-6v7q-wjvx-w8wg
- basic-ftp <= 5.2.1 has incomplete CRLF injection protection allowing arbitrary FTP command execution
- basic-ftp is a transitive dependency pulled in by puppeteer

## Test plan
- [x] `npm install --package-lock-only` succeeds with 0 vulnerabilities
- [x] `package-lock.json` shows basic-ftp 5.2.2
- [ ] Verify Dependabot alert #17 auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)